### PR TITLE
Use color variables

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+TBA
+----------------------
+- Enh: use color variables
 
 1.1.3 (January 8, 2024)
 ----------------------

--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
   "keywords": ["business card, popover, hover, profile information"],
   "version": "1.1.3",
   "humhub": {
-    "minVersion": "1.12"
+    "minVersion": "1.14"
   },
    "homepage": "https://github.com/humhub-contrib/popover-vcard",
   "authors": [

--- a/resources/humhub.vcard.popover.css
+++ b/resources/humhub.vcard.popover.css
@@ -8,7 +8,7 @@
 }
 
 .vcardContent {
-    background-color: white;
+    background-color: var(--background-color-main);
     width: 500px !important;
 }
 
@@ -21,18 +21,18 @@
 .vcardHeader .displayName {
     padding-top: 10px;
     font-size: 24px;
-    color: white
+    color: var(--text-color-contrast)
 }
 
 .vcardHeader .title {
     font-size: 16px;
-    color: white
+    color: var(--text-color-contrast)
 }
 
 .vcardHeader .imageWrapper {
     margin: 8px;
     margin-right: 16px;
-    background-color: white;
+    background-color: var(--background-color-main);
     padding: 2px;
 }
 
@@ -43,7 +43,7 @@
 
 .vcardFooter {
     border-top: 1px solid #c5c5c5;
-    background-color: #EDEDED;
+    background-color: var(--background-color-page);
     height: 55px;
     line-height: 40px;
     padding-left: 6px;
@@ -52,7 +52,7 @@
 
 .vcardPopover {
     max-width: 700px;
-    background-color: #EDEDED;
+    background-color: var(--background-color-page);
     padding: 0 !important;
 }
 

--- a/resources/humhub.vcard.popover.css
+++ b/resources/humhub.vcard.popover.css
@@ -21,12 +21,12 @@
 .vcardHeader .displayName {
     padding-top: 10px;
     font-size: 24px;
-    color: var(--text-color-contrast)
+    color: white
 }
 
 .vcardHeader .title {
     font-size: 16px;
-    color: var(--text-color-contrast)
+    color: white
 }
 
 .vcardHeader .imageWrapper {
@@ -38,11 +38,11 @@
 
 .vcardBody {
     padding: 6px;
-    border-top: 1px solid #c5c5c5;
+    border-top: 1px solid var(--background3);
 }
 
 .vcardFooter {
-    border-top: 1px solid #c5c5c5;
+    border-top: 1px solid var(--background3);
     background-color: var(--background-color-page);
     height: 55px;
     line-height: 40px;


### PR DESCRIPTION
This would fix the popover in dark mode, see https://github.com/felixhahnweilheim/humhub-dark-mode/issues/45

Let me know if you like this solution. Otherwise I'll find a solution within the dark mode module.

Only disadvantage is that the minVersion for HumHub increases to 1.14. There the CSS variables were introduced.