### PR TITLE
Remove square background from round profile image

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 TBA
 ----------------------
 - Enh: use color variables
+- Fix: Remove square background from round profile image
 
 1.1.3 (January 8, 2024)
 ----------------------

--- a/resources/humhub.vcard.popover.css
+++ b/resources/humhub.vcard.popover.css
@@ -32,7 +32,6 @@
 .vcardHeader .imageWrapper {
     margin: 8px;
     margin-right: 16px;
-    background-color: var(--background-color-main);
     padding: 2px;
 }
 


### PR DESCRIPTION
The user profile image renders with a white background, which yields a confusing visual

![image](https://github.com/humhub-contrib/popover-vcard/assets/90508808/330ef838-b929-4c0a-8949-ba95e2f62e18)

especially when members configure a profile and banner image.

By removing the background the visual becomes cleaner
![image](https://github.com/humhub-contrib/popover-vcard/assets/90508808/4c7a44cf-cc4f-41e4-9eec-76d70b2c64c9)
and aligned with how profile & banner images overlap in the `People` view.

